### PR TITLE
Add QC visualizer for image saturation

### DIFF
--- a/src/contraqctor/qc/camera.py
+++ b/src/contraqctor/qc/camera.py
@@ -225,6 +225,7 @@ class CameraTestSuite(Suite):
         )
 
     def test_create_pixel_saturation_visualizer(self):
+        """Creates a visualization highlighting saturated and underexposed pixels in the video frame."""
         data = self.data_stream.data
         if not data.has_video:
             return self.skip_test("No video data available. Skipping test.")
@@ -259,6 +260,7 @@ class CameraTestSuite(Suite):
                 ax[channel].imshow(colored_frame)
                 ax[channel].axis("off")
                 ax[channel].set_title(f"Channel-{channel}")
+
             fig.subplots_adjust(top=0.9)  # Leave space for suptitle
             fig.suptitle("Pixel Saturation Visualization (bounds: {})".format(self.saturation_bounds))
             fig.tight_layout()


### PR DESCRIPTION
This PR adds a new qc routine to the Camera suite that shows saturated pixels in all channels of the image.

To reproduce: 

```python
from contraqctor.contract.camera import Camera, CameraParams
from contraqctor.qc import Runner
from contraqctor.qc.camera import CameraTestSuite

camera = Camera(
    "camera",
    reader_params=CameraParams(
        path=r"\\allen\aind\scratch\bruno.cruz\808728_2025-10-10T161409Z\behavior-videos\FaceCamera"
    ),
)

suite = CameraTestSuite(camera)

runner = Runner()
camera.load_all()
runner.add_suite(suite)

results = runner.run_all_with_progress()

for test in results[None]:
    if isinstance(test.context, dict) and "asset" in test.context.keys():
        test.context["asset"].asset.savefig(f"{test.test_name}.png")

```
